### PR TITLE
Support Termux in ansible.builtin.package

### DIFF
--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -47,6 +47,7 @@ PKG_MGRS = [{'path': '/usr/bin/rpm-ostree', 'name': 'atomic_container'},
             {'path': '/usr/sbin/sorcery', 'name': 'sorcery'},
             {'path': '/usr/bin/installp', 'name': 'installp'},
             {'path': '/QOpenSys/pkgs/bin/yum', 'name': 'yum'},
+            {'path': '/data/data/com.termux/files/usr/bin/apt', 'name': 'apt'},
             ]
 
 


### PR DESCRIPTION
##### SUMMARY

This enables usage of `ansible.builtin.package` instead of `ansible.builtin.apt` in Termux environments (Android). Tested on Pixel Fold and Pixel 6.

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

Example playbook:
```
- hosts: example
  tasks:
    - name: Install packages
      ansible.builtin.package:
        update_cache: yes
        name:
          - gitui
```

Fails because it can't find `apt`:

```paste below
TASK [Install packages] 
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: NoneType: None
fatal: [example]: FAILED! => {"changed": false, "msg": "Could not find a module for unknown."}
```

Fixed after adding the right path:

```
TASK [Install packages] 
changed: [example]
```
